### PR TITLE
Some updates to how nfs/portmap is handled

### DIFF
--- a/manifests/client/ubuntu.pp
+++ b/manifests/client/ubuntu.pp
@@ -8,7 +8,7 @@ class nfs::client::ubuntu inherits nfs::base {
     ensure    => running,
     enable    => true,
     hasstatus => false,
-    status    => "service postmap status | grep -q 'start/running'",
+    status    => "service portmap status | grep -q 'start/running'",
     require   => Package["rpcbind"],
   }
 

--- a/manifests/client/ubuntu.pp
+++ b/manifests/client/ubuntu.pp
@@ -1,6 +1,6 @@
 class nfs::client::ubuntu inherits nfs::base {
 
-  package { ["nfs-common", "portmap"]:
+  package { ["nfs-common", "rpcbind"]:
     ensure => present,
   }
 
@@ -8,7 +8,8 @@ class nfs::client::ubuntu inherits nfs::base {
     ensure    => running,
     enable    => true,
     hasstatus => false,
-    require   => Package["portmap"],
+    status    => "service postmap status | grep -q 'start/running'",
+    require   => Package["rpcbind"],
   }
 
 }


### PR DESCRIPTION
Should now correctly detect portmap's status and updated to the correct package.
NOTE that this RP requires this puppet-hilary commit;
  aa9373c53848fa774ef50577a504c7bdc3e1adcd
